### PR TITLE
Add: org.gradle.configureondemand=true flag to the android/gradle.pro…

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+org.gradle.configureondemand=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
…perties file.

This should trigger the creation of the assembleAarProfile task.

When running the GitHub job, the AAR build failed with the message:
"Task 'assembleAarProfile' not found in root project 'ouisync_plugin'."