### PR TITLE
Fix macos build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The former is done with the command:
 
 The latter is then done from the root folder of this repository:
 
+    $ flutter pub get
     $ flutter pub run ffigen
 
 Note that the above needs to be done every time the public interface of the

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A flutter plugin providing high-level dart API for the ouisync native library.
 
 ## Building the native library
 
+You will need the following installed:
+- rustup
+- cargo (which gets installed with rustup)
+- llvm
+- flutter
+
+On macos, we recommend installing Apple's Xcode command line tools, which include a working llvm installation.
+
 The native library is built automatically as part of this plugins build
 process, but it needs the following prerequisities to be satisfied first:
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ Note that the above needs to be done every time the public interface of the
 
 ## Building the AAR
 
-Note that one doesn't need to build the `.aar` file manually as it should be
-done automatically by the upper level project. See the
-[`ouisync-app`](https://github.com/equalitie/ouisync-app/blob/master/pubspec.yaml)
+You normally don't build the `.aar` file manually. Rather, it gets
+built as a depdendecy of whatever app uses this plugin. See the
+[`ouisync-app`](https://github.com/equalitie/ouisync-app/blob/040eb7216c0c48cc4de75c8d36a0d68267320854/pubspec.yaml)
 for an example.
 
-If - however - building the standalone `.aar` file is indeed desirable, runnig:
+If, however, you want to build a standalone `.aar` file, run
 
     $ flutter build aar
 
-will create a release, debug and a profile build for `arm32`, `arm64` and
+This will create release, debug and profile builds for `arm32`, `arm64` and
 `x86_64` architectures (32bit `x86` is omited by default).
 
-To build only certain architectures or add the missing ones, add the
+To build only for certain architectures or add missing ones, add the
 `--target-platform={android-arm,android-arm64,android-x86,android-x64}` flag to
 the above command.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ ffigen:
   # default locations. In such case uncomment the below line and set it to the
   # correct path. For a bit more info: https://pub.dev/packages/ffigen
   #llvm-path: ['/usr/lib/llvm-14/lib/libclang.so']
+  # If you are on a mac and have installed the Xcode command line tools, you
+  # can find the correct path by running:
+  #    mdfind -name libclang.dylib
   headers:
     entry-points:
       - './ouisync/target/bindings.h'


### PR DESCRIPTION
There needs to be a `podspec.lock` file, so I added a line to build one. I realize we aren't committing one because it's a library that should support multiple versions of its dependencies.

I also rephrased some stuff I thought was helpful. Obv I'm new here; criticism is appreciated.